### PR TITLE
Upgrade version of the payload_data protocol

### DIFF
--- a/Worker.php
+++ b/Worker.php
@@ -242,7 +242,7 @@ function returnCurlRequest($payload, $url, $type) {
  * @return string - Returns a json_encoded string with all of the events to be sent.
  */
 function returnPostRequest($buffer) {
-    $post_req_schema = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-1";
+    $post_req_schema = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4";
     $data = json_encode(array("schema" => $post_req_schema, "data" => $buffer));
     return $data;
 }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -52,7 +52,7 @@ class Constants {
     const CONTEXT_SCHEMA        = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1";
     const UNSTRUCT_EVENT_SCHEMA = "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0";
     const SCREEN_VIEW_SCHEMA    = "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0";
-    const POST_REQ_SCHEMA       = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-2";
+    const POST_REQ_SCHEMA       = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4";
     const DEFAULT_PLATFORM      = "srv";
     const POST_PATH             = "/com.snowplowanalytics.snowplow/tp2";
     const POST_CONTENT_TYPE     = "application/json; charset=utf-8";

--- a/tests/tests/IntegrationTest.php
+++ b/tests/tests/IntegrationTest.php
@@ -40,7 +40,7 @@ class IntegrationTest extends TestCase {
 
     // Helper Functions & Values
 
-    private $payload_schema = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-2";
+    private $payload_schema = "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4";
 
     // Tracker, Emitter & Context Builders
 


### PR DESCRIPTION
Currently, we're using version 1-0-2 of the protocol, and so far, that
has worked well for us. However, to send the value for the
domain_sessionid [1], we need to upgrade it to the latest version.

[1]: https://github.com/Werkspot/snowplow-php-tracker/commit/bc8095f95e7337cf0490c85a8224e583dd9e18f8